### PR TITLE
Stay on 2.0 until webui catches up with the 404/wall error

### DIFF
--- a/shinken_basic/Dockerfile
+++ b/shinken_basic/Dockerfile
@@ -13,7 +13,7 @@ RUN         apt-get update && apt-get install -y python-pip \
                 apt-get -y autoremove && \
                 apt-get clean
 RUN         useradd --create-home shinken && \
-                pip install shinken && \
+                pip install shinken==2.0 && \
                 update-rc.d -f shinken remove
 
 # Install shinken modules from shinken.io

--- a/shinken_thruk/Dockerfile
+++ b/shinken_thruk/Dockerfile
@@ -12,7 +12,7 @@ RUN         apt-get update && apt-get install -y python-pip \
                 libapache2-mod-proxy-html \
                 supervisor
 RUN         useradd --create-home shinken && \
-                pip install shinken && \
+                pip install shinken==2.0 && \
                 update-rc.d -f apache2 remove && \
                 update-rc.d -f shinken remove
 

--- a/shinken_thruk_graphite/Dockerfile
+++ b/shinken_thruk_graphite/Dockerfile
@@ -14,7 +14,7 @@ RUN         apt-get update && apt-get install -y python-pip \
                 python-dev \
                 python-cairo
 RUN         useradd --create-home shinken && \
-                pip install shinken && \
+                pip install shinken==2.0 && \
                 update-rc.d -f apache2 remove && \
                 update-rc.d -f shinken remove
 


### PR DESCRIPTION
The Shinken WebUI seems to be broken on the 2.2 release. The best would be to stay on 2.0 until it catches up.
