### PR TITLE
makes docker container time-zone aware using environment variables

### DIFF
--- a/shinken_basic/docker-compose.yml
+++ b/shinken_basic/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   shinken:
     build:
       context: .
+    environment:
+    - "TZ=UTC"  # UTC can be replaced by any valid timezone.
     ports:
       - "80:80"
     volumes:

--- a/shinken_thruk/docker-compose.yml
+++ b/shinken_thruk/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   shinken:
     build:
       context: .
+    environment:
+    - "TZ=UTC"  # UTC can be replaced by any valid timezone.
     ports:
       - "80:80"
     volumes:

--- a/shinken_thruk_graphite/docker-compose.yml
+++ b/shinken_thruk_graphite/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   shinken:
     build:
       context: .
+    environment:
+    - "TZ=UTC"  # UTC can be replaced by any valid timezone.
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
Adds the environment variable `TZ` to the docker-compose file. This makes it really easy for the web interfaces to display the correct local time in all the checks. It defaults to UTC which is the default right now, so unless the user specifically changes this setting, the project should not behave any different.
